### PR TITLE
change FSGPDayLaps to return datetimes

### DIFF
--- a/data_tools/collections/fsgp_2024_laps.py
+++ b/data_tools/collections/fsgp_2024_laps.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import pathlib
-from datetime import datetime
+import datetime
 import pytz
 
 
@@ -43,7 +43,7 @@ class FSGPDayLaps:
     @staticmethod
     def _pad_timestamp(timestamp: str) -> str:
         """
-        Pad a timestamp to match HH:MM:SS format
+        Pad a string timestamp to match HH:MM:SS format
 
         :param timestamp: timestamp with H:MM:SS or HH:MM:SS format
         :return: timestamp in HH:MM:SS format
@@ -59,10 +59,10 @@ class FSGPDayLaps:
     def get_lap_count(self) -> int:
         return self.df.index.max()
 
-    def _get_utc(self, time_str: str) -> str:
+    def _get_utc_str(self, time_str: str) -> str:
 
         date_time_str = f"{'2024-07-'}{15 + self.day} {time_str}"
-        naive_datetime = datetime.strptime(date_time_str, "%Y-%m-%d %H:%M:%S")
+        naive_datetime = datetime.datetime.strptime(date_time_str, "%Y-%m-%d %H:%M:%S")
 
         central_tz = pytz.timezone('America/Chicago')
         local_datetime = central_tz.localize(naive_datetime)
@@ -71,7 +71,31 @@ class FSGPDayLaps:
         # Format the UTC time to ISO 8601 string format
         return utc_datetime.strftime("%Y-%m-%dT%H:%M:%S") + "Z"
 
-    def get_start_utc(self, lap: int) -> str:
+    def get_start_utc(self, lap: int) -> datetime:
+        """
+        Get lap start time as a UTC datetime object
+
+        :param lap: Lap number from the race day
+        :return: Start time as a UTC datetime object
+        """
+        timestamp_str = self.get_start_utc_string(lap)
+        # remove last "Z" char
+        return (datetime.datetime.strptime(timestamp_str[:-1], "%Y-%m-%dT%H:%M:%S")
+                .replace(tzinfo=datetime.timezone.utc))
+
+    def get_finish_utc(self, lap: int) -> datetime:
+        """
+        Get lap finish time as a UTC datetime object
+
+        :param lap: Lap number from the race day
+        :return: Finish time as a UTC datetime object
+        """
+        timestamp_str = self.get_finish_utc_string(lap)
+        # remove last "Z" char
+        return (datetime.datetime.strptime(timestamp_str[:-1], "%Y-%m-%dT%H:%M:%S")
+                .replace(tzinfo=datetime.timezone.utc))
+
+    def get_start_utc_string(self, lap: int) -> str:
         """
         Get lap start time as a UTC timestamp
 
@@ -84,9 +108,9 @@ class FSGPDayLaps:
             time_str = start_time
         else:
             time_str = self.df.loc[lap - 1, 'Finish Time (HH:MM:SS)']
-        return self._get_utc(time_str)
+        return self._get_utc_str(time_str)
 
-    def get_finish_utc(self, lap: int) -> str:
+    def get_finish_utc_string(self, lap: int) -> str:
         """
         Get lap finish time as a UTC timestamp
 
@@ -95,7 +119,7 @@ class FSGPDayLaps:
         """
         assert lap > 0, "Lap number must be greater than zero; first lap is lap 1"
         time_str = self.df.loc[lap, 'Finish Time (HH:MM:SS)']
-        return self._get_utc(time_str)
+        return self._get_utc_str(time_str)
 
     def get_time(self, lap: int) -> str:
         """

--- a/tests/test_fsgp_laps.py
+++ b/tests/test_fsgp_laps.py
@@ -1,21 +1,52 @@
 import pytest
 from data_tools import FSGPDayLaps
+import datetime
 
 
 def test_lap_start_finish():
     day_1_laps = FSGPDayLaps(1)
-    assert day_1_laps.get_start_utc(1) == "2024-07-16T15:00:00Z"
-    assert day_1_laps.get_finish_utc(1) == "2024-07-16T15:07:04Z"
-    assert day_1_laps.get_start_utc(5) == "2024-07-16T15:27:21Z"
-    assert day_1_laps.get_start_utc(33) == "2024-07-16T18:56:36Z"
+    assert day_1_laps.get_start_utc_string(1) == "2024-07-16T15:00:00Z"
+    assert day_1_laps.get_finish_utc_string(1) == "2024-07-16T15:07:04Z"
+    assert day_1_laps.get_start_utc_string(5) == "2024-07-16T15:27:21Z"
+    assert day_1_laps.get_start_utc_string(33) == "2024-07-16T18:56:36Z"
+    assert day_1_laps.get_start_utc(1) == datetime.datetime(
+        2024, 7, 16, 15, 0, 0, tzinfo=datetime.timezone.utc
+    )
+    assert day_1_laps.get_finish_utc(1) == datetime.datetime(
+        2024, 7, 16, 15, 7, 4, tzinfo=datetime.timezone.utc
+    )
+    assert day_1_laps.get_start_utc(5) == datetime.datetime(
+        2024, 7, 16, 15, 27, 21, tzinfo=datetime.timezone.utc
+    )
+    assert day_1_laps.get_start_utc(33) == datetime.datetime(
+        2024, 7, 16, 18, 56, 36, tzinfo=datetime.timezone.utc
+    )
     day_2_laps = FSGPDayLaps(2)
-    assert day_2_laps.get_start_utc(1) == "2024-07-17T18:22:09Z"
-    assert day_2_laps.get_start_utc(3) == "2024-07-17T18:47:04Z"
-    assert day_2_laps.get_finish_utc(3) == "2024-07-17T18:59:09Z"
+    assert day_2_laps.get_start_utc_string(1) == "2024-07-17T18:22:09Z"
+    assert day_2_laps.get_start_utc_string(3) == "2024-07-17T18:47:04Z"
+    assert day_2_laps.get_finish_utc_string(3) == "2024-07-17T18:59:09Z"
+    assert day_2_laps.get_start_utc(1) == datetime.datetime(
+        2024, 7, 17, 18, 22, 9, tzinfo=datetime.timezone.utc
+    )
+    assert day_2_laps.get_start_utc(3) == datetime.datetime(
+        2024, 7, 17, 18, 47, 4, tzinfo=datetime.timezone.utc
+    )
+    assert day_2_laps.get_finish_utc(3) == datetime.datetime(
+        2024, 7, 17, 18, 59, 9, tzinfo=datetime.timezone.utc
+    )
     day_3_laps = FSGPDayLaps(3)
-    assert day_3_laps.get_start_utc(24) == "2024-07-18T17:04:40Z"
-    assert day_3_laps.get_start_utc(47) == "2024-07-18T21:15:00Z"
-    assert day_3_laps.get_finish_utc(49) == "2024-07-18T21:57:05Z"
+    assert day_3_laps.get_start_utc_string(24) == "2024-07-18T17:04:40Z"
+    assert day_3_laps.get_start_utc_string(47) == "2024-07-18T21:15:00Z"
+    assert day_3_laps.get_finish_utc_string(49) == "2024-07-18T21:57:05Z"
+    assert day_3_laps.get_start_utc(24) == datetime.datetime(
+        2024, 7, 18, 17, 4, 40, tzinfo=datetime.timezone.utc
+    )
+    assert day_3_laps.get_start_utc(47) == datetime.datetime(
+        2024, 7, 18, 21, 15, 0, tzinfo=datetime.timezone.utc
+    )
+    assert day_3_laps.get_finish_utc(49) == datetime.datetime(
+        2024, 7, 18, 21, 57, 5, tzinfo=datetime.timezone.utc
+    )
 
 
 def test_lap_count():


### PR DESCRIPTION
- `get_start_utc` now returns a datetime, with `get_start_utc_string` supporting the previous string format.
- `get_finish_utc` now returns a datetime, with `get_finish_utc_string` supporting the previous string format.