### PR TITLE
Add Sunbeam Cache and Distinct Endpoint

### DIFF
--- a/data_tools/query/__init__.py
+++ b/data_tools/query/__init__.py
@@ -29,7 +29,7 @@ from .flux import FluxQuery, FluxStatement
 from .influxdb_query import DBClient, TimeSeriesTarget
 from .postgresql_query import PostgresClient
 from .data_schema import get_sensor_id, get_data_units, CANLog, init_schema
-from ._sunbeam import SunbeamClient
+from ._sunbeam import SunbeamClient, SunbeamCache
 
 __all__ = [
     "FluxQuery",
@@ -40,5 +40,6 @@ __all__ = [
     "get_sensor_id",
     "get_data_units",
     "init_schema",
-    "SunbeamClient"
+    "SunbeamClient",
+    "SunbeamCache"
 ]

--- a/data_tools/query/_sunbeam.py
+++ b/data_tools/query/_sunbeam.py
@@ -1,11 +1,97 @@
+import base64
 from dotenv import load_dotenv
 import os
 import requests
 from data_tools.schema import File, Result, CanonicalPath
 import dill
+import json
 
 
 load_dotenv()
+
+
+class SunbeamCache:
+    def __init__(self, api_url: str = None):
+        """
+        Create a client to connect to the Sunbeam Cache API.
+
+        Uses ``api_url`` if set, or by default "api.sunbeam.ubcsolar.com/cache".
+        """
+        self._base_url = api_url or "api.sunbeam.ubcsolar.com/cache"
+
+    def _build_url(self, *components):
+        """
+        Construct the full URL for the given endpoint components.
+        """
+        return "http://" + "/".join([self._base_url] + list(components))
+
+    @staticmethod
+    def _handle_error(response):
+        """Handle HTTP errors consistently."""
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError:
+            reason = response.reason
+            if isinstance(reason, bytes):
+                reason = reason.decode("utf-8")
+            raise RuntimeError(reason)
+
+    def __getitem__(self, item):
+        url = self._build_url("get")
+        response = requests.get(url, params={"key": item})
+
+        # If we found the cached item, return it
+        if response.status_code == 200:
+            encoded_data = response.content
+            serialized_data = base64.b64decode(encoded_data)
+
+            return dill.loads(serialized_data)
+
+        # Otherwise if the item wasn't found
+        elif response.status_code == 406:
+            raise KeyError(response.text)
+
+        # Or if we encountered some other error
+        else:
+            SunbeamCache._handle_error(response)
+
+    def __setitem__(self, key, value):
+        url = self._build_url("set")
+        serialized_data = dill.dumps(value)
+        encoded_data = base64.b64encode(serialized_data).decode("utf-8")
+        response = requests.get(url, params={"key": key, "value": encoded_data})
+
+        # Handle the error if the set failed
+        if response.status_code != 201:
+            SunbeamCache._handle_error(response)
+
+    def __contains__(self, item):
+        url = self._build_url("exists")
+        response = requests.get(url, params={"key": item})
+
+        # Decode the response to a bool, as Flask encodes `True` into `"True"` when emitting the response
+        if response.status_code == 200:
+            return response.text.strip().lower() == "true"
+
+        else:
+            SunbeamCache._handle_error(response)
+
+    def __delitem__(self, key):
+        url = self._build_url("delete")
+        response = requests.get(url, params={"key": key})
+
+        if response.status_code != 200:
+            SunbeamCache._handle_error(response)
+
+    def keys(self):
+        url = self._build_url("keys")
+        response = requests.get(url)
+
+        if response.status_code != 200:
+            SunbeamCache._handle_error(response)
+
+        else:
+            return json.loads(response.content)
 
 
 class SunbeamClient:
@@ -24,6 +110,13 @@ class SunbeamClient:
             api_url = os.getenv("SUNBEAM_URL") if "SUNBEAM_URL" in os.environ.keys() else "api.sunbeam.ubcsolar.com"
 
         self._base_url = api_url
+
+    @property
+    def cache(self):
+        """
+        Acquire an interface to the Sunbeam Cache API, descended from this client.
+        """
+        return SunbeamCache(self._base_url + "/cache")
 
     def get_file(self, origin: str = None, event: str = None, source: str = None, name: str = None, path: CanonicalPath = None) -> Result[File | Exception]:
         """


### PR DESCRIPTION
## Features

1. Add the `SunbeamCache` object, which can be indexed like a dictionary and defines a global cache that is connected to Sunbeam. Can be created manually, or as a child of an existing `SunbeamClient` by accessing the property `client.cache`.
2. Add the `distinct` endpoint to `SunbeamClient` which is a view into the `MongoDB.Collection.distinct` method for users of Sunbeam to access its database.
