### PR TITLE
Remove Python 3.12+ syntax

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.12
+    - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
         python-version: "3.12"

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Example of querying data from InfluxDB and plotting it as a `TimeSeries`.
 > When the `InfluxClient` class is imported, `data_tools` will attempt to locate a `.env` file in order to acquire an InfluxDB API token. If you do not have a `.env` or it is missing an API token, you will not be able to query data. UBC Solar members can acquire an API token by speaking to their Team Lead.
 
 ```python
-from data_tools.collections.time_series import TimeSeries
-from data_tools.query.influxdb_query import DBClient
+from data_tools.collections import TimeSeries
+from data_tools.query import DBClient
 
 client = DBClient()
 
@@ -98,9 +98,8 @@ Example of using the `FluxQuery` module to make a Flux query that selects and ag
 We will use the `FluxStatement` class to construct a custom Flux statement, as the `aggregateWindow` statement is not yet included by this API.
 
 ```python
-from data_tools.query.flux import FluxQuery, FluxStatement
-from data_tools.query.influxdb_query import DBClient
-from data_tools.collections.time_series import TimeSeries
+from data_tools.query import FluxQuery, FluxStatement, DBClient
+from data_tools.collections import TimeSeries
 import pandas as pd
 
 client = DBClient()

--- a/data_tools/schema/_event.py
+++ b/data_tools/schema/_event.py
@@ -3,7 +3,7 @@ from data_tools.utils.times import parse_iso_datetime, ensure_utc
 from typing import Union, List
 
 
-type DateLike = Union[str, datetime.datetime]
+DateLike = Union[str, datetime.datetime]
 
 
 class Event:


### PR DESCRIPTION
# FIX: Remove Python 3.12+ syntax

- [x] Linter Check Succeeded
- [x] All Tests Succeeded
- [x] Module Documentation
- [x] Method/Class/Function Documentation
- [x] Documentation Correctly Builds
- [x] Sufficent Test Code Coverage   
- [x] Pull Request Completed 

## What's New
[What has been added?]

## Bugfixes
[Have you added any bug fixes?]

## Deprecated/Removed
[Has anything been removed or deprecated?]

## Dependencies
[Any changes in dependencies?]

## Notes
[Anything else relevant?]

